### PR TITLE
[EZ1-T21] - Splash screen verify keep logged

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         android:theme="@style/AppTheme.NoActionBar"
         tools:targetApi="31">
         <activity
-            android:name=".splash.SplashActivity"
+            android:name=".splash.ui.SplashActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/example/loginmvvm/App.kt
+++ b/app/src/main/java/com/example/loginmvvm/App.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.example.loginmvvm.access.signin.di.SignInModule
 import com.example.loginmvvm.access.signup.di.SignUpModule
 import com.example.loginmvvm.common.data.local.cache.di.CacheModule
+import com.example.loginmvvm.splash.di.SplashModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
@@ -18,6 +19,7 @@ class App: Application() {
             koin.loadModules(
                 listOf(
                     CacheModule.instance,
+                    SplashModule.instance,
                     SignInModule.instance,
                     SignUpModule.instance
                 )

--- a/app/src/main/java/com/example/loginmvvm/splash/data/cache/SplashCache.kt
+++ b/app/src/main/java/com/example/loginmvvm/splash/data/cache/SplashCache.kt
@@ -1,0 +1,16 @@
+package com.example.loginmvvm.splash.data.cache
+
+import com.example.loginmvvm.common.data.local.cache.Cache
+import com.example.loginmvvm.common.data.local.cache.CacheImpl.Companion.USER_KEEP_LOGGED
+
+class SplashCacheImpl(
+    private val cache: Cache
+): SplashCache {
+    override suspend fun getKeepLogged(): Boolean {
+       return cache.get(USER_KEEP_LOGGED).toBoolean()
+    }
+}
+
+interface SplashCache {
+    suspend fun getKeepLogged(): Boolean
+}

--- a/app/src/main/java/com/example/loginmvvm/splash/data/repository/SplashRepository.kt
+++ b/app/src/main/java/com/example/loginmvvm/splash/data/repository/SplashRepository.kt
@@ -1,0 +1,13 @@
+package com.example.loginmvvm.splash.data.repository
+
+import com.example.loginmvvm.splash.data.cache.SplashCache
+
+class SplashRepositoryImpl(
+    private val splashCache: SplashCache
+): SplashRepository {
+    override suspend fun getKeepLogged() = splashCache.getKeepLogged()
+}
+
+interface SplashRepository {
+    suspend fun getKeepLogged(): Boolean
+}

--- a/app/src/main/java/com/example/loginmvvm/splash/di/SplashModule.kt
+++ b/app/src/main/java/com/example/loginmvvm/splash/di/SplashModule.kt
@@ -1,0 +1,17 @@
+package com.example.loginmvvm.splash.di
+
+import com.example.loginmvvm.splash.data.cache.SplashCache
+import com.example.loginmvvm.splash.data.cache.SplashCacheImpl
+import com.example.loginmvvm.splash.data.repository.SplashRepository
+import com.example.loginmvvm.splash.data.repository.SplashRepositoryImpl
+import com.example.loginmvvm.splash.ui.SplashViewModel
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.dsl.module
+
+object SplashModule {
+    val instance = module {
+        single<SplashCache> { SplashCacheImpl(cache = get()) }
+        factory<SplashRepository> { SplashRepositoryImpl(splashCache = get()) }
+        viewModel { SplashViewModel(repository = get()) }
+    }
+}

--- a/app/src/main/java/com/example/loginmvvm/splash/ui/SplashActivity.kt
+++ b/app/src/main/java/com/example/loginmvvm/splash/ui/SplashActivity.kt
@@ -1,4 +1,4 @@
-package com.example.loginmvvm.splash
+package com.example.loginmvvm.splash.ui
 
 import android.annotation.SuppressLint
 import android.os.Bundle
@@ -7,11 +7,14 @@ import android.os.Looper
 import androidx.appcompat.app.AppCompatActivity
 import com.example.loginmvvm.access.AccessActivity
 import com.example.loginmvvm.databinding.ActivitySplashBinding
+import com.example.loginmvvm.main.MainActivity
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
 @SuppressLint("CustomSplashScreen")
-class SplashActivity: AppCompatActivity() {
+class SplashActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivitySplashBinding
+    private val viewModel by viewModel<SplashViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -21,10 +24,19 @@ class SplashActivity: AppCompatActivity() {
     }
 
     private fun handlerScreens() {
-        Handler(Looper.getMainLooper()).postDelayed({
-            startActivity(AccessActivity.newIntent(this))
-            finish()
-        }, TIMER)
+        viewModel.getKeepLogged()
+
+        viewModel.keepLogged.observe(this) {
+            Handler(Looper.getMainLooper()).postDelayed({
+                if (it) {
+                    startActivity(MainActivity.newIntent(this))
+                    finish()
+                } else {
+                    startActivity(AccessActivity.newIntent(this))
+                    finish()
+                }
+            }, TIMER)
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/example/loginmvvm/splash/ui/SplashViewModel.kt
+++ b/app/src/main/java/com/example/loginmvvm/splash/ui/SplashViewModel.kt
@@ -1,0 +1,21 @@
+package com.example.loginmvvm.splash.ui
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.loginmvvm.splash.data.repository.SplashRepository
+import kotlinx.coroutines.launch
+
+class SplashViewModel(
+    private val repository: SplashRepository
+): ViewModel() {
+
+    private val _keepLogged: MutableLiveData<Boolean> = MutableLiveData()
+    val keepLogged = _keepLogged as LiveData<Boolean>
+
+    fun getKeepLogged() = viewModelScope.launch {
+        val response = repository.getKeepLogged()
+        _keepLogged.postValue(response)
+    }
+}

--- a/app/src/test/java/com/example/loginmvvm/splash/data/cache/SplashCacheTest.kt
+++ b/app/src/test/java/com/example/loginmvvm/splash/data/cache/SplashCacheTest.kt
@@ -1,0 +1,35 @@
+package com.example.loginmvvm.splash.data.cache
+
+import com.example.loginmvvm.common.data.local.cache.Cache
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Test
+
+class SplashCacheTest {
+    private lateinit var cache: Cache
+    private lateinit var splashCache: SplashCache
+
+    @Test
+    fun `given user is keepLogged then return cache result`() = runTest {
+        startCache(isKeepLogged = true)
+        val keepLogged = splashCache.getKeepLogged()
+        Assert.assertEquals(true, keepLogged)
+    }
+
+    @Test
+    fun `given user is not keepLogged then return cache result`() = runTest {
+        startCache(isKeepLogged = false)
+        val keepLogged = splashCache.getKeepLogged()
+        Assert.assertEquals(false, keepLogged)
+    }
+
+    private fun startCache(isKeepLogged: Boolean) {
+        cache = object : Cache {
+            override suspend fun insert(key: String, value: String) = Unit
+            override suspend fun update(key: String, value: String)  = Unit
+            override suspend fun delete(key: String)  = Unit
+            override suspend fun get(key: String) = isKeepLogged.toString()
+        }
+        splashCache = SplashCacheImpl(cache)
+    }
+}

--- a/app/src/test/java/com/example/loginmvvm/splash/data/repository/SplashRepositoryTest.kt
+++ b/app/src/test/java/com/example/loginmvvm/splash/data/repository/SplashRepositoryTest.kt
@@ -1,0 +1,41 @@
+package com.example.loginmvvm.splash.data.repository
+
+import com.example.loginmvvm.splash.data.cache.SplashCache
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Test
+
+class SplashRepositoryTest {
+    private val cache: SplashCache = mockk(relaxed = true)
+    private val repository: SplashRepository = SplashRepositoryImpl(cache)
+
+    @Test
+    fun `given repository is call then verify cache is call`() = runTest {
+        coEvery { cache.getKeepLogged() } returns true
+
+        repository.getKeepLogged()
+
+        coVerify { cache.getKeepLogged() }
+    }
+
+    @Test
+    fun `given user is keepLogged then return cache result`() = runTest {
+        coEvery { cache.getKeepLogged() } returns true
+
+        val keepLogged = repository.getKeepLogged()
+
+        Assert.assertEquals(true, keepLogged)
+    }
+
+    @Test
+    fun `given user is not keepLogged then return cache result`() = runTest {
+        coEvery { cache.getKeepLogged() } returns false
+
+        val keepLogged = repository.getKeepLogged()
+
+        Assert.assertEquals(false, keepLogged)
+    }
+}

--- a/app/src/test/java/com/example/loginmvvm/splash/ui/SplashViewModelTest.kt
+++ b/app/src/test/java/com/example/loginmvvm/splash/ui/SplashViewModelTest.kt
@@ -1,0 +1,76 @@
+package com.example.loginmvvm.splash.ui
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
+import com.example.loginmvvm.splash.data.repository.SplashRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class SplashViewModelTest {
+
+    @get:Rule
+    var testSchedulerRule = InstantTaskExecutorRule()
+
+    @OptIn(DelicateCoroutinesApi::class)
+    private val mainThreadSurrogate = newSingleThreadContext("Unit thread")
+
+    private val repository: SplashRepository = mockk(relaxed = true)
+    private val viewModel: SplashViewModel = SplashViewModel(repository)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(mainThreadSurrogate)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        mainThreadSurrogate.close()
+    }
+
+    @Test
+    fun `when call repository then verify repository is called`() {
+        coEvery { repository.getKeepLogged() } returns true
+
+        viewModel.getKeepLogged()
+
+        coVerify { repository.getKeepLogged() }
+    }
+
+    @Test
+    fun `when call getKeepLogged then return user connected`() {
+        val observerConnected : Observer<Boolean> = mockk(relaxed = true)
+        viewModel.keepLogged.observeForever(observerConnected)
+
+        coEvery { repository.getKeepLogged() } returns true
+
+        viewModel.getKeepLogged()
+
+        coVerify { observerConnected.onChanged(true) }
+    }
+
+    @Test
+    fun `when call getKeepLogged then return user not connected`() {
+        val observerConnected : Observer<Boolean> = mockk(relaxed = true)
+        viewModel.keepLogged.observeForever(observerConnected)
+
+        coEvery { repository.getKeepLogged() } returns false
+
+        viewModel.getKeepLogged()
+
+        coVerify { observerConnected.onChanged(false) }
+    }
+}


### PR DESCRIPTION
### Descrição, motivação e contexto

Verificar se existe a opção continuar conectado para permitir o acesso

Ticket do Jira: [[EZ1-T21]](https://projects.zoho.com/portal/marcioorges18gmaildotcom#taskdetail/2154533000000047925/2154533000000056001/2154533000000056003)


### Print da tela e/ou link do Abstract

Coloque aqui um print das telas alteradas ou um vídeo do fluxo

[Protótipo no Abstract](COLOQUE-O-LINK)

### PR's relacionadas

Adicione aqui as PR’s relacionadas (caso haja mais de uma).

### Como sua mudança pode ser testada?

Por favor, descreva um passo a passo
```
1. acesse o app
2. ao logar selecione a opção "continuar conectado"
3.
```

### Checklist:

Antes de pedir que façam a leitura e análise do pull-request de uma olhada no checklist e marque conforme tenha feito:

#### Geral:
- [x] Fiz o merge da develop com minha branch.
- [x] Realizei uma auto-revisão do meu próprio código.
- [x] Adicionei o label correspondente ao tipo de mudança
- [x] Eu rodei o detekt localmente.
- [x] Minhas alterações não geraram novos warnings.
- [x] Meu código está de acordo com o padão android
- [ ] As mensagens de commit estão em português.
- [ ] Eu adicionei dois revisores sendo um o ponto focal da Business Unit *Se aplicável*

---

#### Testes:
- [ ] Minha alteração requer uma alteração nos testes de UI.
- [ ] Eu atualizei o teste de UI de acordo.
- [x] Eu criei teste unitários para novos métodos.  
- [x] Eu rodei os testes unitários localmente.
